### PR TITLE
Use HTTPS for gradle repositories

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ version = getVersionCode()
 
 repositories {
 	mavenCentral()
-	maven { url "http://clojars.org/repo/" }
+	maven { url "https://clojars.org/repo/" }
 }
 
 application {

--- a/gradle/codacy_coverage.gradle
+++ b/gradle/codacy_coverage.gradle
@@ -2,7 +2,7 @@ configurations { codacy }
 
 repositories {
 	maven { url "https://jitpack.io" }
-	maven { url "http://dl.bintray.com/typesafe/maven-releases" }
+	maven { url "https://dl.bintray.com/typesafe/maven-releases" }
 }
 
 dependencies {


### PR DESCRIPTION
Seems like HTTP is disabled on newer versions of Gradle, so this changes the two remaining HTTP repositories to HTTPS.